### PR TITLE
Tile color

### DIFF
--- a/R/waffle.R
+++ b/R/waffle.R
@@ -48,6 +48,7 @@
 #' @param use_glyph use specified FontAwesome glyph
 #' @param glyph_size size of the FontAwesome font
 #' @param legend_pos position of legend
+#' @param tile_color color of tile or glyph border
 #' @export
 #' @examples
 #' parts <- c(80, 30, 20, 10)

--- a/R/waffle.R
+++ b/R/waffle.R
@@ -68,7 +68,8 @@
 #' # print(chart)
 waffle <- function(parts, rows=10, keep=TRUE, xlab=NULL, title=NULL, colors=NA,
                    size=2, flip=FALSE, reverse=FALSE, equal=TRUE, pad=0,
-                   use_glyph=FALSE, glyph_size=12, legend_pos="right") {
+                   use_glyph=FALSE, glyph_size=12, legend_pos="right", 
+                   tile_color = "white") {
 
   if (inherits(parts, "data.frame")) {
     setNames(unlist(parts[,2], use.names = FALSE),
@@ -122,7 +123,7 @@ waffle <- function(parts, rows=10, keep=TRUE, xlab=NULL, title=NULL, colors=NA,
 
   if (inherits(use_glyph, "logical")) {
 
-    gg <- gg + geom_tile(aes(fill=value), color="white", size=size)
+    gg <- gg + geom_tile(aes(fill=value), color=tile_color, size=size)
     gg <- gg + scale_fill_manual(name="",
                                  values=colors,
                                  label=part_names,
@@ -149,7 +150,7 @@ waffle <- function(parts, rows=10, keep=TRUE, xlab=NULL, title=NULL, colors=NA,
       message("Font Awesome by Dave Gandy - http://fontawesome.io")
     }
 
-    gg <- gg + geom_tile(color="#00000000", fill="#00000000", size=size, alpha=0, show.legend=FALSE)
+    gg <- gg + geom_tile(color=tile_color, fill="#00000000", size=size, alpha=0, show.legend=FALSE)
     gg <- gg + geom_point(aes(color=value), fill="#00000000", size=0, show.legend=TRUE)
     gg <- gg + geom_text(aes(color=value,label=fontlab),
                          family="FontAwesome", size=glyph_size, show.legend=FALSE)

--- a/man/waffle.Rd
+++ b/man/waffle.Rd
@@ -41,6 +41,8 @@ ggsave or knitr to control output sizes (or manually sizing the chart)}
 \item{glyph_size}{size of the FontAwesome font}
 
 \item{legend_pos}{position of legend}
+
+\item{tile_color}{color of tile or glyph border}
 }
 \description{
 Given a named vector or a data frame, this function will return a ggplot object that

--- a/man/waffle.Rd
+++ b/man/waffle.Rd
@@ -6,7 +6,8 @@
 \usage{
 waffle(parts, rows = 10, keep = TRUE, xlab = NULL, title = NULL,
   colors = NA, size = 2, flip = FALSE, reverse = FALSE, equal = TRUE,
-  pad = 0, use_glyph = FALSE, glyph_size = 12, legend_pos = "right")
+  pad = 0, use_glyph = FALSE, glyph_size = 12, legend_pos = "right",
+  tile_color = "white")
 }
 \arguments{
 \item{parts}{named vector of values or a data frame to use for the chart}


### PR DESCRIPTION
Added `tile_color` argument to `waffle` function. This is passed to the `color` argument of `geom_tile`. This creates the tile border color which allows the user to match the tile borders to the panel background.